### PR TITLE
Scale controller updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changes on the `main` branch, but not yet released, will be listed here.
 
 -   [[#27](https://github.com/diatche/LibreChart/pull/27)] When specifying an axes on a plot, passing `true` for an axis-type will add a default axis, and passing `false` or `undefined` for an axis-type will not add an axis.
 
+### Breaking Changes
+
+-   The type `ScaleHysteresisFunction` is now `Hysteresis.StepFunc`.
+
 ## 0.5.0
 
 **17 Mar 2021**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changes on the `main` branch, but not yet released, will be listed here.
 -   [[#27](https://github.com/diatche/LibreChart/pull/27)] When specifying an axes on a plot, passing `true` for an axis-type will add a default axis, and passing `false` or `undefined` for an axis-type will not add an axis.
 -   Moved content padding and hysteresis options from `AutoScaleController` to `ScaleController`, allowing `FixedScaleController` to be configured in the same way.
 
+### Bug Fixes
+
+-   `AutoScaleController` max limit fixed.
+
 ### Breaking Changes
 
 -   The type `ScaleHysteresisFunction` is now `Hysteresis.StepFunc`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@ Changes on the `main` branch, but not yet released, will be listed here.
 ### Features
 
 -   [[#27](https://github.com/diatche/LibreChart/pull/27)] When specifying an axes on a plot, passing `true` for an axis-type will add a default axis, and passing `false` or `undefined` for an axis-type will not add an axis.
--   Moved content padding and hysteresis options from `AutoScaleController` to `ScaleController`, allowing `FixedScaleController` to be configured in the same way.
+-   [[#28](https://github.com/diatche/LibreChart/pull/28)] Moved content padding and hysteresis options from `AutoScaleController` to `ScaleController`, allowing `FixedScaleController` to be configured in the same way.
 
 ### Bug Fixes
 
--   `AutoScaleController` max limit fixed.
+-   [[#28](https://github.com/diatche/LibreChart/pull/28)] `AutoScaleController` max limit fixed.
 
 ### Breaking Changes
 
--   The type `ScaleHysteresisFunction` is now `Hysteresis.StepFunc`.
--   `AutoScaleController` no longer adds content padding by default.
--   Content padding is now applied after `min` and `max` limits on scale controllers.
+-   [[#28](https://github.com/diatche/LibreChart/pull/28)] The type `ScaleHysteresisFunction` is now `Hysteresis.StepFunc`.
+-   [[#28](https://github.com/diatche/LibreChart/pull/28)] `AutoScaleController` no longer adds content padding by default.
+-   [[#28](https://github.com/diatche/LibreChart/pull/28)] Content padding is now applied after `min` and `max` limits on scale controllers.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ Changes on the `main` branch, but not yet released, will be listed here.
 ### Features
 
 -   [[#27](https://github.com/diatche/LibreChart/pull/27)] When specifying an axes on a plot, passing `true` for an axis-type will add a default axis, and passing `false` or `undefined` for an axis-type will not add an axis.
+-   Moved content padding and hysteresis options from `AutoScaleController` to `ScaleController`, allowing `FixedScaleController` to be configured in the same way.
 
 ### Breaking Changes
 
 -   The type `ScaleHysteresisFunction` is now `Hysteresis.StepFunc`.
+-   `AutoScaleController` no longer adds content padding by default.
+-   Content padding is now applied after `min` and `max` limits on scale controllers.
 
 ## 0.5.0
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export * from './scale/DiscreteScale';
 export { default as DecimalLinearScale } from './scale/DecimalLinearScale';
 export * from './scale/DecimalLinearScale';
 
+export * from './scaleControllers/Hysteresis';
+
 export { default as FixedScaleController } from './scaleControllers/FixedScaleController';
 export * from './scaleControllers/FixedScaleController';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,6 @@ export * from './scale/DiscreteScale';
 export { default as DecimalLinearScale } from './scale/DecimalLinearScale';
 export * from './scale/DecimalLinearScale';
 
-export * from './scaleControllers/Hysteresis';
-
 export { default as FixedScaleController } from './scaleControllers/FixedScaleController';
 export * from './scaleControllers/FixedScaleController';
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -3,6 +3,7 @@ export * from './theme';
 
 export { default as ScaleController } from './scaleControllers/ScaleController';
 export * from './scaleControllers/ScaleController';
+export * from './scaleControllers/Hysteresis';
 
 export { default as ScaleLayout } from './layout/ScaleLayout';
 export * from './layout/ScaleLayout';

--- a/src/scaleControllers/Hysteresis.ts
+++ b/src/scaleControllers/Hysteresis.ts
@@ -1,0 +1,101 @@
+import Scale, { ITickScaleConstraints } from '../scale/Scale';
+
+export namespace Hysteresis {
+    export type StepFunc = (
+        min: number,
+        max: number,
+        previousMin: number | undefined,
+        previousMax: number | undefined,
+    ) => [number, number] | null;
+
+    export const none: StepFunc = () => null;
+
+    export const step = (
+        size: number,
+        options: {
+            origin?: number;
+        } = {},
+    ): StepFunc => {
+        if (size <= 0) {
+            throw new Error('Invalid step');
+        }
+        let { origin = 0 } = options;
+        return (a, b) => [
+            Math.floor((a - origin) / size) * size + origin,
+            Math.ceil((b - origin) / size) * size + origin,
+        ];
+    };
+
+    export function withScale<T = any, D = any>(scale: Scale<T, D>): StepFunc {
+        let constraints: ITickScaleConstraints<D> = {
+            expand: true,
+        };
+        return (a, b) => {
+            scale.updateTickScale(
+                scale.valueAtLocation(a),
+                scale.valueAtLocation(b),
+                constraints,
+            );
+            return scale.spanLocationRange(a, b);
+        };
+    }
+
+    // export const log10 = (
+    //     options: {
+    //         step?: number;
+    //         origin?: number;
+    //     } = {},
+    // ): ScaleHysteresisFunction => {
+    //     let {
+    //         step = 1,
+    //         origin = 0,
+    //     } = options;
+    //     if (step <= 0) {
+    //         throw new Error('Invalid stepCoef');
+    //     }
+    //     return (a, b) => {
+    //         if (a === b) {
+    //             // Zero range
+    //             return null;
+    //         }
+    //         a -= origin;
+    //         b -= origin;
+    //         if (a > 0 && b < 0 || a < 0 && b > 0) {
+    //             // Different sign
+    //             return null;
+    //         }
+    //         let isNeg = a < 0;
+    //         let sign = 1;
+    //         let floor = Math.floor;
+    //         let ceil = Math.ceil;
+    //         if (isNeg) {
+    //             sign = -1;
+    //             a = -a;
+    //             b = -b;
+    //             floor = Math.ceil;
+    //             ceil = Math.floor;
+    //         }
+
+    //         let al = Math.log10(a);
+    //         if (step === 1) {
+    //             al = floor(al);
+    //         } else {
+    //             let al0 = floor(al);
+    //             al = floor((al - al0) / step) * step + al0;
+    //         }
+
+    //         let bl = Math.log10(b);
+    //         if (step === 1 || !isFinite(bl)) {
+    //             bl = ceil(bl);
+    //         } else {
+    //             let bl0 = floor(bl);
+    //             bl = ceil((bl - bl0) / step) * step + bl0;
+    //         }
+
+    //         return [
+    //             Math.pow(base, al) * sign + origin,
+    //             Math.pow(base, bl) * sign + origin,
+    //         ];
+    //     };
+    // };
+}


### PR DESCRIPTION
### Features

-   Moved content padding and hysteresis options from `AutoScaleController` to `ScaleController`, allowing `FixedScaleController` to be configured in the same way.

### Bug Fixes

-   `AutoScaleController` max limit fixed.

### Breaking Changes

-   The type `ScaleHysteresisFunction` is now `Hysteresis.StepFunc`.
-   `AutoScaleController` no longer adds content padding by default.
-   Content padding is now applied after `min` and `max` limits on scale controllers.