### PR TITLE
Custom axis labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes on the `main` branch, but not yet released, will be listed here.
 -   [[#27](https://github.com/diatche/LibreChart/pull/27)] When specifying an axes on a plot, passing `true` for an axis-type will add a default axis, and passing `false` or `undefined` for an axis-type will not add an axis.
 -   [[#28](https://github.com/diatche/LibreChart/pull/28)] Moved content padding and hysteresis options from `AutoScaleController` to `ScaleController`, allowing `FixedScaleController` to be configured in the same way.
 -   [[#32](https://github.com/diatche/LibreChart/pull/32)] Added `syncThickness` and `unsyncThickness` methods to `Axis`, which allow synchronizing multiple axes' thicknesses.
+-   The `Axis` configuration option `getTickLabel` now accepts custom render methods.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changes on the `main` branch, but not yet released, will be listed here.
 -   [[#27](https://github.com/diatche/LibreChart/pull/27)] When specifying an axes on a plot, passing `true` for an axis-type will add a default axis, and passing `false` or `undefined` for an axis-type will not add an axis.
 -   [[#28](https://github.com/diatche/LibreChart/pull/28)] Moved content padding and hysteresis options from `AutoScaleController` to `ScaleController`, allowing `FixedScaleController` to be configured in the same way.
 -   [[#32](https://github.com/diatche/LibreChart/pull/32)] Added `syncThickness` and `unsyncThickness` methods to `Axis`, which allow synchronizing multiple axes' thicknesses.
--   The `Axis` configuration option `getTickLabel` now accepts custom render methods.
+-   [[#33](https://github.com/diatche/LibreChart/pull/33)] The `Axis` configuration option `getTickLabel` now accepts custom render methods.
 
 ### Bug Fixes
 

--- a/src/components/ChartAxisContent.tsx
+++ b/src/components/ChartAxisContent.tsx
@@ -4,6 +4,7 @@ import {
     LayoutChangeEvent,
     StyleSheet,
     Text,
+    TextProps,
     TextStyle,
     View,
     ViewProps,
@@ -51,6 +52,10 @@ export default class ChartAxisContent<T> extends React.PureComponent<
             let label = this.props.getTickLabel(tick);
             if (typeof label === 'string') {
                 label = { title: label };
+            } else if (typeof label === 'function') {
+                label = { title: '', render: label };
+            } else if (typeof label === 'undefined' || label === null) {
+                label = { title: '' };
             }
             return label;
         } catch (error) {
@@ -229,16 +234,22 @@ export default class ChartAxisContent<T> extends React.PureComponent<
         let labelInnerContainers: React.ReactNode[] = [];
 
         for (let i = 0; i < labels.length; i++) {
+            const label = labels[i];
             ticks.push(<View key={i} style={tickStyle} />);
+
+            const labelProps: TextProps = {
+                selectable: false,
+                style: [labelStyle, labels[i].style],
+            };
+            const labelContent = label.render ? (
+                label.render(labelProps)
+            ) : !!label.title ? (
+                <Text {...labelProps}>{label.title}</Text>
+            ) : null;
 
             labelInnerContainers.push(
                 <View key={i} style={labelInnerContainerStyle}>
-                    <Text
-                        selectable={false}
-                        style={[labelStyle, labels[i].style]}
-                    >
-                        {labels[i].title}
-                    </Text>
+                    {labelContent}
                 </View>,
             );
         }

--- a/src/layout/axis/axisTypes.ts
+++ b/src/layout/axis/axisTypes.ts
@@ -72,7 +72,9 @@ export interface IAxisOptions<T = any> {
      **/
     hidden: boolean;
 
-    getTickLabel: (tick: ITickVector<T>) => string | ITickLabel;
+    getTickLabel: (
+        tick: ITickVector<T>,
+    ) => ITickLabel | ITickLabel['title'] | ITickLabel['render'];
 
     onThicknessChange?: (thickness: number, previousThickness: number) => void;
     onOptimalThicknessChange?: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface IRectStyle extends IFillStyle, IStrokeStyle {
 export interface ITickLabel {
     title: string;
     style?: TextStyle;
+    render?: (props: any) => any;
 }
 
 export interface IDecimalPoint {


### PR DESCRIPTION
The `Axis` configuration option `getTickLabel` now accepts custom render methods.