### PR TITLE
Fix labels in iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ Changes on the `main` branch, but not yet released, will be listed here.
 
 -   `ILabelStyle` now has a `viewLayout` property, which contains `offset`, `size` and `anchor` properties.
 -   `ILabelStyle.textStyle` now takes animated values.
+-   Added `axisThickness` to `IAxisStyle`, which fixes the axis thickness to a value or animated value.
 
 ### Bug Fixes
 
 -   Text labels were not showing on iOS.
+-   Axes were not showing on iOS.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes on the `main` branch, but not yet released, will be listed here.
 ### Features
 
 -   `ILabelStyle` now has a `viewLayout` property, which contains `offset`, `size` and `anchor` properties.
+-   `ILabelStyle.textStyle` now takes animated values.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 Changes on the `main` branch, but not yet released, will be listed here.
 
+### Features
+
+-   `ILabelStyle` now has a `viewLayout` property, which contains `offset`, `size` and `anchor` properties.
+
+### Bug Fixes
+
+-   Text labels were not showing on iOS.
+
+### Breaking Changes
+
+-   `LabelDataSource` now expects separate view and text alignments, specified by `ILabelStyle.viewLayout.anchor` and `ILabelStyle.align` respectively.
+-   Removed `viewOffset` from `ILabelStyle`. Use `viewLayout.offset` instead.
+-   Removed `numberOfLines` from `ILabelStyle`. Use `viewLayout.size` to limit the size.
+
 ## 0.7.1
 
 **22 Apr 2021**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,20 @@ Changes on the `main` branch, but not yet released, will be listed here.
 
 ### Features
 
--   `ILabelStyle` now has a `viewLayout` property, which contains `offset`, `size` and `anchor` properties.
--   `ILabelStyle.textStyle` now takes animated values.
--   Added `axisThickness` to `IAxisStyle`, which fixes the axis thickness to a value or animated value.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] `ILabelStyle` now has a `viewLayout` property, which contains `offset`, `size` and `anchor` properties.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] `ILabelStyle.textStyle` now takes animated values.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] Added `axisThickness` to `IAxisStyle`, which fixes the axis thickness to a value or animated value.
 
 ### Bug Fixes
 
--   Text labels were not showing on iOS.
--   Axes were not showing on iOS.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] Text labels were not showing on iOS.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] Axes were not showing on iOS.
 
 ### Breaking Changes
 
--   `LabelDataSource` now expects separate view and text alignments, specified by `ILabelStyle.viewLayout.anchor` and `ILabelStyle.align` respectively.
--   Removed `viewOffset` from `ILabelStyle`. Use `viewLayout.offset` instead.
--   Removed `numberOfLines` from `ILabelStyle`. Use `viewLayout.size` to limit the size.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] `LabelDataSource` now expects separate view and text alignments, specified by `ILabelStyle.viewLayout.anchor` and `ILabelStyle.align` respectively.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] Removed `viewOffset` from `ILabelStyle`. Use `viewLayout.offset` instead.
+-   [[#36](https://github.com/diatche/LibreChart/pull/36)] Removed `numberOfLines` from `ILabelStyle`. Use `viewLayout.size` to limit the size.
 
 ## 0.7.1
 

--- a/src/components/ChartAxisContent.tsx
+++ b/src/components/ChartAxisContent.tsx
@@ -18,6 +18,7 @@ import {
 import { ITickVector } from '../scale/Scale';
 import ChartLabel, { ChartLabelProps } from './ChartLabel';
 import { kDefaultAxisLabelAlignments } from '../const';
+import _ from 'lodash';
 
 export interface ChartAxisContentProps<T>
     extends ViewProps,
@@ -222,8 +223,8 @@ export default class ChartAxisContent<T> extends React.PureComponent<
     getLabelInnerContainerStyle() {
         // TODO: cache style until prop change
         let style: Animated.AnimatedProps<ViewProps>['style'] = {
-            marginLeft: this.props.labelStyle.viewOffset?.x,
-            marginTop: this.props.labelStyle.viewOffset?.y,
+            marginLeft: this.props.labelStyle.viewLayout?.offset?.x,
+            marginTop: this.props.labelStyle.viewLayout?.offset?.y,
         };
         switch (this.props.axisType) {
             case 'topAxis':
@@ -303,9 +304,11 @@ export default class ChartAxisContent<T> extends React.PureComponent<
         const defaultLabelAlignment = this.getDefaultLabelAlignment();
         const isHorizontal = this.isHorizontal;
         const labelDefaults: Partial<ChartLabelProps> = {
-            ignoreBounds: true,
-            textWidth: isHorizontal ? this.props.labelLength : 0,
-            textHeight: isHorizontal ? 0 : this.props.labelLength,
+            viewLayout: {
+                size: isHorizontal
+                    ? { x: this.props.labelLength }
+                    : { y: this.props.labelLength },
+            },
         };
 
         for (let i = 0; i < labels.length; i++) {
@@ -315,8 +318,8 @@ export default class ChartAxisContent<T> extends React.PureComponent<
             let labelInnerContainerStyle = [
                 labelInnerContainerBaseStyle,
                 {
-                    marginLeft: label.viewOffset?.x,
-                    marginTop: label.viewOffset?.y,
+                    marginLeft: label.viewLayout?.offset?.x,
+                    marginTop: label.viewLayout?.offset?.y,
                 },
             ];
             let align = this.displayLabelAlignment({
@@ -326,8 +329,7 @@ export default class ChartAxisContent<T> extends React.PureComponent<
             labelInnerContainers.push(
                 <Animated.View key={i} style={labelInnerContainerStyle}>
                     <ChartLabel
-                        {...labelDefaults}
-                        {...label}
+                        {..._.merge({}, labelDefaults, label)}
                         alignX={align.x}
                         alignY={align.y}
                         textStyle={[labelStyle, label.textStyle]}

--- a/src/components/ChartAxisContent.tsx
+++ b/src/components/ChartAxisContent.tsx
@@ -3,12 +3,16 @@ import {
     Animated,
     LayoutChangeEvent,
     StyleSheet,
-    TextStyle,
     View,
     ViewProps,
     ViewStyle,
 } from 'react-native';
-import { Alignment2D, ITickLabel, normalizedLabelSafe } from '../types';
+import {
+    Alignment2D,
+    ILabelStyle,
+    ITickLabel,
+    normalizedLabelSafe,
+} from '../types';
 import {
     AxisType,
     AxisTypeMapping,
@@ -16,7 +20,7 @@ import {
     IAxisStyle,
 } from '../layout/axis/axisTypes';
 import { ITickVector } from '../scale/Scale';
-import ChartLabel, { ChartLabelProps } from './ChartLabel';
+import ChartLabel from './ChartLabel';
 import { kDefaultAxisLabelAlignments } from '../const';
 import _ from 'lodash';
 
@@ -303,13 +307,10 @@ export default class ChartAxisContent<T> extends React.PureComponent<
 
         const defaultLabelAlignment = this.getDefaultLabelAlignment();
         const isHorizontal = this.isHorizontal;
-        const labelDefaults: Partial<ChartLabelProps> = {
-            viewLayout: {
-                size: isHorizontal
-                    ? { x: this.props.labelLength }
-                    : { y: this.props.labelLength },
-            },
-        };
+        const labelTextStyle: ILabelStyle['textStyle'] = isHorizontal
+            ? { width: this.props.majorViewInterval }
+            : { height: this.props.majorViewInterval };
+        labelStyle = [labelStyle, labelTextStyle];
 
         for (let i = 0; i < labels.length; i++) {
             const label = labels[i];
@@ -329,10 +330,14 @@ export default class ChartAxisContent<T> extends React.PureComponent<
             labelInnerContainers.push(
                 <Animated.View key={i} style={labelInnerContainerStyle}>
                     <ChartLabel
-                        {..._.merge({}, labelDefaults, label)}
+                        {...label}
                         alignX={align.x}
                         alignY={align.y}
-                        textStyle={[labelStyle, label.textStyle]}
+                        textStyle={[
+                            label.textStyle,
+                            labelStyle,
+                            labelTextStyle,
+                        ]}
                     />
                 </Animated.View>
             );

--- a/src/components/ChartAxisContent.tsx
+++ b/src/components/ChartAxisContent.tsx
@@ -26,8 +26,9 @@ import _ from 'lodash';
 
 export interface ChartAxisContentProps<T>
     extends ViewProps,
-        Required<IAxisStyle> {
+        Required<Omit<IAxisStyle, 'axisThickness'>> {
     axisType: AxisType;
+    targetThickness?: number;
     /** Tick locations in ascending order in content coordinates. */
     ticks: ITickVector<T>[];
     /** Set to `true` if the axis scale is negative. */
@@ -95,9 +96,18 @@ export default class ChartAxisContent<T> extends React.PureComponent<
      */
     getInnerContainerStyle() {
         // TODO: cache style until prop change
+        let style: Animated.AnimatedProps<ViewStyle> = {};
+        if (this.props.targetThickness) {
+            if (this.isHorizontal) {
+                style.height = this.props.targetThickness;
+            } else {
+                style.width = this.props.targetThickness;
+            }
+        }
         return [
             styles.innerContainer,
             axisStyles[this.props.axisType].innerContainer,
+            style,
         ];
     }
 
@@ -312,8 +322,7 @@ export default class ChartAxisContent<T> extends React.PureComponent<
             : { height: this.props.majorViewInterval };
         labelStyle = [labelStyle, labelTextStyle];
 
-        for (let i = 0; i < labels.length; i++) {
-            const label = labels[i];
+        labels.forEach((label, i) => {
             ticks.push(<View key={i} style={tickStyle} />);
 
             let labelInnerContainerStyle = [
@@ -341,7 +350,7 @@ export default class ChartAxisContent<T> extends React.PureComponent<
                     />
                 </Animated.View>
             );
-        }
+        });
 
         return (
             <Animated.View style={this.getContainerStyle()}>
@@ -392,8 +401,7 @@ const styles = StyleSheet.create({
         // borderColor: 'rgba(100, 210, 130, 0.5)',
     },
     label: {
-        // borderWidth: 2,
-        // borderColor: 'rgba(200, 110, 130, 0.5)',
+        // backgroundColor: 'rgba(200, 110, 130, 0.5)',
     },
     placeholder: {
         width: 0,

--- a/src/components/ChartLabel.tsx
+++ b/src/components/ChartLabel.tsx
@@ -13,61 +13,46 @@ export interface ChartLabelProps
         Animated.AnimatedProps<ViewProps> {
     alignX?: Alignment2D['x'];
     alignY?: Alignment2D['y'];
-    textWidth?: number;
-    textHeight?: number;
-    ignoreBounds?: boolean;
 }
 
 const ChartLabel = (props: ChartLabelProps) => {
     const {
         alignX = 'center',
         alignY = 'center',
-        textWidth,
-        textHeight,
         title,
-        numberOfLines,
         textStyle,
         style,
         render,
         ...otherProps
     } = props;
 
-    const isFixedWidth = (textWidth || 0) > 0;
-    const isFixedHeight = (textHeight || 0) > 0;
-
-    const { ignoreBounds = isFixedWidth || isFixedHeight } = props;
-
     const textProps: Animated.AnimatedProps<TextProps> = {
         selectable: false,
         style: [{ textAlign: alignX }, textStyle],
-        numberOfLines,
     };
+
+    let content: React.ReactNode;
+    if (render) {
+        content = render(textProps);
+        if (typeof content === 'string') {
+            throw new Error(
+                'Use the title prop to display a basic text string'
+            );
+        }
+    } else {
+        content = <Animated.Text {...textProps}>{title || ''}</Animated.Text>;
+    }
 
     return (
         <Animated.View
             {...otherProps}
             style={[
                 styles.container,
-                {
-                    alignItems: kAlignItemsMapX[alignX],
-                    justifyContent: kAlignContentMapY[alignY],
-                },
+                { justifyContent: kAlignContentMapY[alignY] },
                 style,
             ]}
         >
-            <Animated.View
-                style={[
-                    ignoreBounds ? { alignSelf: kAlignSelfMapX[alignX] } : {},
-                    isFixedWidth ? { width: textWidth } : {},
-                    isFixedHeight ? { height: textHeight } : {},
-                ]}
-            >
-                {render ? (
-                    render(textProps)
-                ) : (
-                    <Animated.Text {...textProps}>{title || ''}</Animated.Text>
-                )}
-            </Animated.View>
+            <Animated.View>{content}</Animated.View>
         </Animated.View>
     );
 };

--- a/src/components/ChartLabel.tsx
+++ b/src/components/ChartLabel.tsx
@@ -58,26 +58,8 @@ const ChartLabel = (props: ChartLabelProps) => {
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-    },
+    container: {},
 });
-
-const kAlignItemsMapX: {
-    [K in Alignment2D['x']]: FlexStyle['alignItems'];
-} = {
-    left: 'flex-start',
-    center: 'center',
-    right: 'flex-end',
-};
-
-const kAlignSelfMapX: {
-    [K in Alignment2D['x']]: FlexStyle['alignSelf'];
-} = {
-    left: 'flex-start',
-    center: 'center',
-    right: 'flex-end',
-};
 
 const kAlignContentMapY: {
     [K in Alignment2D['y']]: FlexStyle['justifyContent'];

--- a/src/components/ChartLabel.tsx
+++ b/src/components/ChartLabel.tsx
@@ -13,23 +13,75 @@ export interface ChartLabelProps
         Animated.AnimatedProps<ViewProps> {
     alignX?: Alignment2D['x'];
     alignY?: Alignment2D['y'];
+    numberOfLines?: number;
+    // onTextLayout?: (size: { width: number; height: number }) => void;
 }
 
 const ChartLabel = (props: ChartLabelProps) => {
     const {
         alignX = 'center',
         alignY = 'center',
+        numberOfLines,
         title,
         textStyle,
         style,
         render,
+        // onTextLayout: onTextLayoutProp,
         ...otherProps
     } = props;
 
+    // const titleSize = React.useRef(new Animated.ValueXY()).current;
+    // const [titleSize, setTitleSize] = React.useState({ text: '', x: 0, y: 0 });
+
+    // const titleSizeTextRef = React.useRef('');
+
     const textProps: Animated.AnimatedProps<TextProps> = {
         selectable: false,
-        style: [{ textAlign: alignX }, textStyle],
+        style: [
+            {
+                textAlign: alignX,
+                // width: titleSize.x,
+                // height: titleSize.y,
+            },
+            // titleSize.text === title
+            //     ? {
+            //           width: titleSize.x,
+            //           height: titleSize.y,
+            //       }
+            //     : undefined,
+            textStyle,
+        ],
+        numberOfLines,
     };
+
+    // const onTextLayout = React.useCallback(
+    //     (event: NativeSyntheticEvent<TextLayoutEventData>) => {
+    //         let text = event.nativeEvent.lines.map(x => x.text).join('\n');
+    //         if (text === titleSizeTextRef.current) {
+    //             // Measure title text only once
+    //             return;
+    //         }
+    //         let width = 0;
+    //         let height = 0;
+    //         for (let line of event.nativeEvent.lines) {
+    //             if (line.width > width) {
+    //                 width = line.width;
+    //             }
+    //             height += line.height;
+    //         }
+    //         titleSizeTextRef.current = text;
+    //         onTextLayoutProp?.({
+    //             width: Math.ceil(width) + 6,
+    //             height: Math.ceil(height),
+    //         });
+    //         // setTitleSize({
+    //         //     text,
+    //         //     x: Math.ceil(width) + 6,
+    //         //     y: Math.ceil(height),
+    //         // });
+    //     },
+    //     [onTextLayoutProp]
+    // );
 
     let content: React.ReactNode;
     if (render) {
@@ -40,7 +92,14 @@ const ChartLabel = (props: ChartLabelProps) => {
             );
         }
     } else {
-        content = <Animated.Text {...textProps}>{title || ''}</Animated.Text>;
+        content = (
+            <Animated.Text
+                {...textProps}
+                // onTextLayout={Platform.OS !== 'web' ? onTextLayout : undefined}
+            >
+                {title || ''}
+            </Animated.Text>
+        );
     }
 
     return (

--- a/src/components/Plot.tsx
+++ b/src/components/Plot.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import Evergrid, {
     EvergridProps,
     IItem,
@@ -225,6 +226,7 @@ export default class Chart extends React.PureComponent<PlotProps, ChartState> {
             <ChartLabel
                 {...itemStyle}
                 {...label}
+                style={styles.flex}
                 alignX={itemStyle?.align?.x || label.align?.x}
                 alignY={itemStyle?.align?.y || label.align?.y}
             />
@@ -256,6 +258,7 @@ export default class Chart extends React.PureComponent<PlotProps, ChartState> {
             <ChartAxisContent
                 {...axis.style}
                 axisType={axis.axisType}
+                targetThickness={axis.layoutInfo.targetThickness}
                 ticks={ticks}
                 getTickLabel={tick => axis?.getTickLabel(tick) || ''}
                 labelLength={labelLength}
@@ -297,3 +300,7 @@ export default class Chart extends React.PureComponent<PlotProps, ChartState> {
         );
     }
 }
+
+const styles = StyleSheet.create({
+    flex: { flex: 1 },
+});

--- a/src/components/Plot.tsx
+++ b/src/components/Plot.tsx
@@ -227,7 +227,6 @@ export default class Chart extends React.PureComponent<PlotProps, ChartState> {
                 {...label}
                 alignX={itemStyle?.align?.x || label.align?.x}
                 alignY={itemStyle?.align?.y || label.align?.y}
-                ignoreBounds
             />
         );
     }

--- a/src/data/LabelDataSource.ts
+++ b/src/data/LabelDataSource.ts
@@ -3,6 +3,7 @@ import {
     IItem,
     IItemCustomLayout,
     LayoutSourceProps,
+    normalizeAnimatedValueOrInterpolation,
 } from 'evergrid';
 import DataSource, { DataSourceInput } from './DataSource';
 import {
@@ -13,6 +14,13 @@ import {
 } from '../types';
 import { Animated } from 'react-native';
 import _ from 'lodash';
+
+const kDefaultLabelStyle: ILabelStyle = {
+    viewLayout: {
+        size: { x: 100, y: 100 },
+        anchor: { x: 0.5, y: 0.5 },
+    },
+};
 
 export interface LabelDataSourceInput<T, X = number, Y = number>
     extends DataSourceInput<T, X, Y> {
@@ -46,7 +54,7 @@ export default class LabelDataSource<T = any, X = number, Y = number>
         super(input);
         this.transform = input.transform;
         this.getLabel = input.getLabel;
-        this.style = { ...input.style };
+        this.style = _.merge({}, kDefaultLabelStyle, input.style || {});
         this.itemStyle = input.itemStyle;
         this._itemStyles = {};
     }
@@ -82,10 +90,11 @@ export default class LabelDataSource<T = any, X = number, Y = number>
         }
         return {
             align: { ...this.style.align, ...itemStyle?.align },
-            viewOffset: {
-                x: itemStyle?.viewOffset?.x || this.style.viewOffset?.x,
-                y: itemStyle?.viewOffset?.y || this.style.viewOffset?.y,
-            },
+            viewLayout: _.merge(
+                {},
+                this.style.viewLayout || {},
+                itemStyle.viewLayout || {}
+            ),
             textStyle: [this.style.textStyle, itemStyle?.textStyle],
         };
     }
@@ -122,20 +131,36 @@ export default class LabelDataSource<T = any, X = number, Y = number>
                 if (options.created) {
                     // Link offset with item
                     let itemStyle = this.getItemStyle(item);
-                    let offsetX =
-                        itemStyle?.viewOffset?.x || this.style.viewOffset?.x;
-                    if (offsetX) {
+                    if (itemStyle?.viewLayout?.offset?.x) {
                         item.animated.viewLayout.offset.x = Animated.add(
                             item.animated.viewLayout.offset.x,
-                            offsetX
+                            itemStyle.viewLayout.offset.x
                         );
                     }
-                    let offsetY =
-                        itemStyle?.viewOffset?.y || this.style.viewOffset?.y;
-                    if (offsetY) {
+                    if (itemStyle?.viewLayout?.offset?.y) {
                         item.animated.viewLayout.offset.y = Animated.add(
                             item.animated.viewLayout.offset.y,
-                            offsetY
+                            itemStyle.viewLayout.offset.y
+                        );
+                    }
+                    if (itemStyle?.viewLayout?.size?.x) {
+                        item.animated.viewLayout.size.x = normalizeAnimatedValueOrInterpolation(
+                            itemStyle.viewLayout.size.x
+                        );
+                    }
+                    if (itemStyle?.viewLayout?.size?.y) {
+                        item.animated.viewLayout.size.y = normalizeAnimatedValueOrInterpolation(
+                            itemStyle.viewLayout.size.y
+                        );
+                    }
+                    if (itemStyle?.viewLayout?.anchor?.x) {
+                        item.animated.viewLayout.anchor.x = normalizeAnimatedValueOrInterpolation(
+                            itemStyle.viewLayout.anchor.x
+                        );
+                    }
+                    if (itemStyle?.viewLayout?.anchor?.y) {
+                        item.animated.viewLayout.anchor.y = normalizeAnimatedValueOrInterpolation(
+                            itemStyle.viewLayout.anchor.y
                         );
                     }
                 }

--- a/src/layout/PlotLayout.ts
+++ b/src/layout/PlotLayout.ts
@@ -105,7 +105,7 @@ export default class PlotLayout<
         input: PlotLayoutManyInput | undefined,
         options?: {
             columns?: boolean;
-        },
+        }
     ): PlotLayout[] {
         if (!input) {
             return [];
@@ -140,7 +140,7 @@ export default class PlotLayout<
             let indexStr = `{ x: ${index.x}, y: ${index.y} }`;
             if (indexes.has(indexStr)) {
                 throw new Error(
-                    `There are more than one plot at index: ${indexStr}`,
+                    `There are more than one plot at index: ${indexStr}`
                 );
             }
             indexes.add(indexStr);
@@ -238,7 +238,7 @@ export default class PlotLayout<
         }
 
         this._scheduledPlotUpdate = InteractionManager.runAfterInteractions(
-            () => this._debouncedPlotUpdate(),
+            () => this._debouncedPlotUpdate()
         );
     }
 
@@ -254,7 +254,7 @@ export default class PlotLayout<
 
     private _debouncedPlotUpdate = debounce(
         () => this.updatePlot(kDefaultUpdateInfo),
-        kGridUpdateDebounceInterval,
+        kGridUpdateDebounceInterval
     );
 
     didUpdate(info: IUpdateInfo) {
@@ -281,7 +281,7 @@ export default class PlotLayout<
     scrollToValueRange(
         start: { x?: X; y?: Y },
         end: { x?: X; y?: Y },
-        options: IAnimationBaseOptions,
+        options: IAnimationBaseOptions
     ) {
         return this.scrollTo({
             ...options,
@@ -399,7 +399,7 @@ export default class PlotLayout<
     }
 
     private _validatedAxes(
-        props: PlotLayoutOptions | undefined,
+        props: PlotLayoutOptions | undefined
     ): IAxes<X, Y, DX, DY> {
         return Axis.createMany(props?.axes, { theme: props?.theme });
     }

--- a/src/layout/ScaleLayout.ts
+++ b/src/layout/ScaleLayout.ts
@@ -9,6 +9,7 @@ import { Observable } from '../utils/observable';
 import ScaleController from '../scaleControllers/ScaleController';
 import DiscreteScale from '../scale/DiscreteScale';
 import AutoScaleController from '../scaleControllers/AutoScaleController';
+import _ from 'lodash';
 
 export interface IScaleLayoutOptions<T = any, D = T> {
     /**
@@ -120,11 +121,21 @@ export default class ScaleLayout<T = number, D = T> {
             majorInterval$: new Animated.Value(0),
             negHalfMajorInterval$: new Animated.Value(0),
         };
-        this.style = {
-            ...kAxisStyleLightDefaults,
-            ...style,
-            padding: normalizeAnimatedValue(style.padding),
-        };
+        let inheritedStyle = kAxisStyleLightDefaults;
+        this.style = _.merge({}, inheritedStyle, {
+            padding: normalizeAnimatedValue(style.padding, {
+                defaults: normalizeAnimatedValue(inheritedStyle.padding),
+            }),
+            axisThickness:
+                typeof style.axisThickness !== 'undefined' ||
+                typeof inheritedStyle.axisThickness !== 'undefined'
+                    ? normalizeAnimatedValue(style.axisThickness, {
+                          defaults: normalizeAnimatedValue(
+                              inheritedStyle.axisThickness
+                          ),
+                      })
+                    : undefined,
+        });
 
         if (!controller && scale instanceof DiscreteScale) {
             controller = new AutoScaleController({

--- a/src/layout/axis/DateAxis.ts
+++ b/src/layout/axis/DateAxis.ts
@@ -1,5 +1,5 @@
 import { Duration, Moment } from 'moment';
-import { StyleProp, TextStyle } from 'react-native';
+import { Animated, TextProps } from 'react-native';
 import { ITickLabel } from '../../types';
 import Axis, { IAxisExtraOptions } from './Axis';
 import {
@@ -16,7 +16,9 @@ export interface IDateAxisOptions extends IAxisOptions<Moment> {
 
 export default class DateAxis extends Axis<Moment, Duration> {
     locale?: string;
-    private _tickStyles?: DateUnitMapping<StyleProp<TextStyle>>;
+    private _tickStyles?: DateUnitMapping<
+        Animated.AnimatedProps<TextProps>['style']
+    >;
 
     constructor(options: Partial<IDateAxisOptions> & IAxisExtraOptions) {
         options = {

--- a/src/layout/axis/axisConst.ts
+++ b/src/layout/axis/axisConst.ts
@@ -1,7 +1,7 @@
 import { AxisType, AxisTypeMapping, IAxisStyle } from './axisTypes';
 import { Colors } from '../../utils/colors';
 import _ from 'lodash';
-import { Animated } from 'react-native';
+import { Animated, Platform } from 'react-native';
 
 export const kAxisContentReuseIDs: AxisTypeMapping<string> = {
     topAxis: 'topAxisContent',
@@ -31,6 +31,8 @@ type IAxisDefaultBaseStyle = Omit<
 >;
 
 export const kAxisStyleBaseDefaults: IAxisDefaultBaseStyle = {
+    // Web measures text in a way that is compatible with automatic axis thickness.
+    axisThickness: Platform.OS === 'web' ? undefined : new Animated.Value(35),
     axisLineThickness: 1,
 
     majorTickLength: 3,

--- a/src/layout/axis/axisTypes.ts
+++ b/src/layout/axis/axisTypes.ts
@@ -33,6 +33,14 @@ export interface IAxisBackgroundLayoutStyle {
 }
 
 export interface IAxisBackgroundStyleInput extends IAxisBackgroundLayoutStyle {
+    /**
+     * The thickness of the axis.
+     *
+     * Specifying this value overrides automatic
+     * axis thickness layout (currently available
+     * only on web).
+     */
+    axisThickness?: AnimatedValueInput;
     axisBackgroundColor?: string;
     axisLineColor?: string;
     axisLineThickness?: number;
@@ -42,7 +50,9 @@ export interface IAxisBackgroundStyleInput extends IAxisBackgroundLayoutStyle {
 }
 
 export interface IAxisBackgroundStyle
-    extends Required<IAxisBackgroundStyleInput> {}
+    extends Required<Omit<IAxisBackgroundStyleInput, 'axisThickness'>> {
+    axisThickness?: Animated.Value;
+}
 
 export interface IAxisStyleInput
     extends IAxisContentStyleInput,
@@ -50,8 +60,11 @@ export interface IAxisStyleInput
     padding?: AnimatedValueInput;
 }
 
-export interface IAxisStyle extends Required<IAxisStyleInput> {
+export interface IAxisStyle
+    extends Required<Omit<IAxisStyleInput, 'axisThickness'>> {
     padding: Animated.Value;
+    /** See {@link IAxisBackgroundStyleInput.axisThickness} */
+    axisThickness?: Animated.Value;
 }
 
 export interface IAxisLayoutSourceProps

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export type Alignment2D = {
 export interface ILabelStyle {
     align?: Partial<Alignment2D>;
     viewLayout?: IPartialLayout<IAnimatedPointInput>;
-    textStyle?: StyleProp<TextStyle>;
+    textStyle?: Animated.AnimatedProps<TextProps>['style'];
 }
 
 export interface ITickLabel extends Omit<ILabelStyle, 'align'> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import Decimal from 'decimal.js';
-import { GridLayoutSourceProps, IAnimatedPointInput, IPoint } from 'evergrid';
+import {
+    GridLayoutSourceProps,
+    IAnimatedPointInput,
+    IPartialLayout,
+    IPoint,
+} from 'evergrid';
 import { Animated, StyleProp, TextProps, TextStyle } from 'react-native';
 
 export type AnimatedValueAny =
@@ -68,14 +73,13 @@ export type Alignment2D = {
 
 export interface ILabelStyle {
     align?: Partial<Alignment2D>;
-    viewOffset?: Partial<IAnimatedPointInput>;
+    viewLayout?: IPartialLayout<IAnimatedPointInput>;
     textStyle?: StyleProp<TextStyle>;
 }
 
 export interface ITickLabel extends Omit<ILabelStyle, 'align'> {
     align?: Partial<Alignment2D>;
     title: string;
-    numberOfLines?: number;
     render?: (props: Animated.AnimatedProps<TextProps>) => any;
 }
 

--- a/src/utils/date/dateStyle.ts
+++ b/src/utils/date/dateStyle.ts
@@ -1,4 +1,4 @@
-import { StyleProp, TextStyle } from 'react-native';
+import { Animated, TextProps } from 'react-native';
 import { IAxisStyle } from '../../layout/axis/axisTypes';
 import {
     DateUnit,
@@ -13,7 +13,7 @@ import { getUniformMs } from './duration';
 export const getTickStyles = (
     duration: moment.Duration,
     style: IAxisStyle
-): DateUnitMapping<StyleProp<TextStyle>> => {
+): DateUnitMapping<Animated.AnimatedProps<TextProps>['style']> => {
     // Find unit which has a regular label style
     let uniformMs = getUniformMs(duration);
     let regularIndex = 0;
@@ -38,8 +38,13 @@ export const getTickStyles = (
     }
 
     return mapDateUnits(
-        (dateUnit: DateUnit, index: number): StyleProp<TextStyle> => {
-            let labelStyle: StyleProp<TextStyle> = [style.labelStyle.textStyle];
+        (
+            dateUnit: DateUnit,
+            index: number
+        ): Animated.AnimatedProps<TextProps>['style'] => {
+            let labelStyle: Animated.AnimatedProps<TextProps>['style'] = [
+                style.labelStyle.textStyle,
+            ];
             if (index === regularIndex || index === otherRegularIndex) {
                 // Regular style
             } else if (index > regularIndex) {


### PR DESCRIPTION
### Features

-   `ILabelStyle` now has a `viewLayout` property, which contains `offset`, `size` and `anchor` properties.
-   `ILabelStyle.textStyle` now takes animated values.
-   Added `axisThickness` to `IAxisStyle`, which fixes the axis thickness to a value or animated value.

### Bug Fixes

-   Text labels were not showing on iOS.
-   Axes were not showing on iOS.

### Breaking Changes

-   `LabelDataSource` now expects separate view and text alignments, specified by `ILabelStyle.viewLayout.anchor` and `ILabelStyle.align` respectively.
-   Removed `viewOffset` from `ILabelStyle`. Use `viewLayout.offset` instead.
-   Removed `numberOfLines` from `ILabelStyle`. Use `viewLayout.size` to limit the size.