### PR TITLE
Label style fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes on the `main` branch, but not yet released, will be listed here.
 -   [[#36](https://github.com/diatche/LibreChart/pull/36)] Text labels were not showing on iOS.
 -   [[#36](https://github.com/diatche/LibreChart/pull/36)] Axes were not showing on iOS.
 -   [[#37](https://github.com/diatche/LibreChart/pull/37)] Fixed an error related to `Text` component with some `LineDataSource` style configurations.
+-   When a background is specified on a label's `textStyle`, it no longer spans the whole item container width.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Changes on the `main` branch, but not yet released, will be listed here.
 
+### Bug Fixes
+
+-   When a background is specified on a label's `textStyle`, it no longer spans the whole item container width.
+-   Fixed merging of axis label text styles.
+
 ## 0.8.0 - 0.8.1
 
 **26 Apr 2021**
@@ -19,8 +24,6 @@ Changes on the `main` branch, but not yet released, will be listed here.
 -   [[#36](https://github.com/diatche/LibreChart/pull/36)] Text labels were not showing on iOS.
 -   [[#36](https://github.com/diatche/LibreChart/pull/36)] Axes were not showing on iOS.
 -   [[#37](https://github.com/diatche/LibreChart/pull/37)] Fixed an error related to `Text` component with some `LineDataSource` style configurations.
--   When a background is specified on a label's `textStyle`, it no longer spans the whole item container width.
--   Fixed merging of axis label text styles.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changes on the `main` branch, but not yet released, will be listed here.
 -   [[#36](https://github.com/diatche/LibreChart/pull/36)] Axes were not showing on iOS.
 -   [[#37](https://github.com/diatche/LibreChart/pull/37)] Fixed an error related to `Text` component with some `LineDataSource` style configurations.
 -   When a background is specified on a label's `textStyle`, it no longer spans the whole item container width.
+-   Fixed merging of axis label text styles.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Changes on the `main` branch, but not yet released, will be listed here.
 
 ### Bug Fixes
 
--   When a background is specified on a label's `textStyle`, it no longer spans the whole item container width.
--   Fixed merging of axis label text styles.
+-   [[#38](https://github.com/diatche/LibreChart/pull/38)] When a background is specified on a label's `textStyle`, it no longer spans the whole item container width.
+-   [[#38](https://github.com/diatche/LibreChart/pull/38)] Fixed merging of axis label text styles.
 
 ## 0.8.0 - 0.8.1
 

--- a/src/components/ChartAxisContent.tsx
+++ b/src/components/ChartAxisContent.tsx
@@ -7,12 +7,7 @@ import {
     ViewProps,
     ViewStyle,
 } from 'react-native';
-import {
-    Alignment2D,
-    ILabelStyle,
-    ITickLabel,
-    normalizedLabelSafe,
-} from '../types';
+import { Alignment2D, ITickLabel, normalizedLabelSafe } from '../types';
 import {
     AxisType,
     AxisTypeMapping,
@@ -285,9 +280,9 @@ export default class ChartAxisContent<T> extends React.PureComponent<
         return style;
     }
 
-    getLabelStyle() {
+    getLabelTextStyle() {
         // TODO: cache style until prop change
-        return [styles.label, this.props.labelStyle.textStyle];
+        return [styles.labelText, this.props.labelStyle.textStyle];
     }
 
     onInnerContainerLayout(event: LayoutChangeEvent) {
@@ -309,18 +304,13 @@ export default class ChartAxisContent<T> extends React.PureComponent<
     render() {
         let labelInnerContainerBaseStyle = this.getLabelInnerContainerStyle();
         let tickStyle = this.getTickStyle();
-        let labelStyle = this.getLabelStyle();
+        let labelTextStyle = this.getLabelTextStyle();
         let labels = this.getTickLabels();
 
         let ticks: React.ReactNode[] = [];
         let labelInnerContainers: React.ReactNode[] = [];
 
         const defaultLabelAlignment = this.getDefaultLabelAlignment();
-        const isHorizontal = this.isHorizontal;
-        const labelTextStyle: ILabelStyle['textStyle'] = isHorizontal
-            ? { width: this.props.majorViewInterval }
-            : { height: this.props.majorViewInterval };
-        labelStyle = [labelStyle, labelTextStyle];
 
         labels.forEach((label, i) => {
             ticks.push(<View key={i} style={tickStyle} />);
@@ -342,11 +332,7 @@ export default class ChartAxisContent<T> extends React.PureComponent<
                         {...label}
                         alignX={align.x}
                         alignY={align.y}
-                        textStyle={[
-                            label.textStyle,
-                            labelStyle,
-                            labelTextStyle,
-                        ]}
+                        textStyle={[labelTextStyle, label.textStyle]}
                     />
                 </Animated.View>
             );
@@ -400,7 +386,7 @@ const styles = StyleSheet.create({
         // borderWidth: 2,
         // borderColor: 'rgba(100, 210, 130, 0.5)',
     },
-    label: {
+    labelText: {
         // backgroundColor: 'rgba(200, 110, 130, 0.5)',
     },
     placeholder: {

--- a/src/components/ChartLabel.tsx
+++ b/src/components/ChartLabel.tsx
@@ -111,14 +111,36 @@ const ChartLabel = (props: ChartLabelProps) => {
                 style,
             ]}
         >
-            <Animated.View>{content}</Animated.View>
+            <Animated.View
+                style={[
+                    styles.innerContainer,
+                    { justifyContent: kAlignContentMapX[alignX] },
+                ]}
+            >
+                {content}
+            </Animated.View>
         </Animated.View>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {},
+    container: {
+        flex: 1,
+        flexDirection: 'column',
+        overflow: 'hidden',
+    },
+    innerContainer: {
+        flexDirection: 'row',
+    },
 });
+
+const kAlignContentMapX: {
+    [K in Alignment2D['x']]: FlexStyle['justifyContent'];
+} = {
+    left: 'flex-start',
+    center: 'center',
+    right: 'flex-end',
+};
 
 const kAlignContentMapY: {
     [K in Alignment2D['y']]: FlexStyle['justifyContent'];

--- a/src/components/Plot.tsx
+++ b/src/components/Plot.tsx
@@ -17,7 +17,8 @@ import { axisTypeMap } from '../layout/axis/axisUtil';
 import RectDataSource from '../data/RectDataSource';
 import ChartRect from './ChartRect';
 import LabelDataSource from '../data/LabelDataSource';
-import ChartLabel from './ChartLabel';
+import ChartLabel, { ChartLabelProps } from './ChartLabel';
+import _ from 'lodash';
 
 type ForwardEvergridProps = Partial<EvergridProps>;
 
@@ -222,11 +223,12 @@ export default class Chart extends React.PureComponent<PlotProps, ChartState> {
         let label = normalizedLabelSafe(
             dataSource.getLabel(dataItem, itemStyle)
         );
+        let props: ChartLabelProps = _.merge({}, itemStyle, label);
+
+        props.textStyle = [itemStyle?.textStyle, label.textStyle];
         return (
             <ChartLabel
-                {...itemStyle}
-                {...label}
-                style={styles.flex}
+                {...props}
                 alignX={itemStyle?.align?.x || label.align?.x}
                 alignY={itemStyle?.align?.y || label.align?.y}
             />

--- a/src/layout/axis/Axis.ts
+++ b/src/layout/axis/Axis.ts
@@ -23,7 +23,7 @@ import {
 } from './axisTypes';
 import { ITickVector } from '../../scale/Scale';
 import { PlotLayout } from '../../internal';
-import { isAxisHorizontal, isAxisType } from './axisUtil';
+import { isAxisHorizontal, isAxisType, mergeAxisStyles } from './axisUtil';
 import { Cancelable } from '../../types';
 import ScaleLayout from '../ScaleLayout';
 import { Observable } from '../../utils/observable';
@@ -151,26 +151,11 @@ export default class Axis<T = any, DT = any> implements IAxisProps<T> {
         this.getTickLabel = getTickLabel;
         this.onOptimalThicknessChange = onOptimalThicknessChange;
         this.onThicknessChange = onThicknessChange;
-        let inheritedStyle = _.merge(
-            {},
+        this.style = mergeAxisStyles(
             kAxisStyleLightDefaults,
             options.theme?.axis,
             style
         );
-        this.style = _.merge({}, inheritedStyle, {
-            padding: normalizeAnimatedValue(style.padding, {
-                defaults: normalizeAnimatedValue(inheritedStyle.padding),
-            }),
-            axisThickness:
-                typeof style.axisThickness !== 'undefined' ||
-                typeof inheritedStyle.axisThickness !== 'undefined'
-                    ? normalizeAnimatedValue(style.axisThickness, {
-                          defaults: normalizeAnimatedValue(
-                              inheritedStyle.axisThickness
-                          ),
-                      })
-                    : undefined,
-        });
         this.isHorizontal = isAxisHorizontal(this.axisType);
         this.layoutInfo = {
             thickness: 0,

--- a/src/layout/axis/axisUtil.ts
+++ b/src/layout/axis/axisUtil.ts
@@ -1,9 +1,19 @@
-import { AxisType, AxisTypeMapping } from './axisTypes';
+import {
+    AxisType,
+    AxisTypeMapping,
+    IAxisStyle,
+    IAxisStyleInput,
+} from './axisTypes';
 import {
     kAllAxisTypes,
     kAllAxisTypeSet,
+    kAxisStyleLightDefaults,
     kHorizontalAxisTypes,
 } from './axisConst';
+import _ from 'lodash';
+import { normalizeAnimatedValue } from 'evergrid';
+import { DeepPartial } from '../../types';
+import { Animated, TextProps } from 'react-native';
 
 export const isAxisType = (axisType: any): axisType is AxisType => {
     return kAllAxisTypeSet.has(axisType as any);
@@ -13,11 +23,44 @@ export const isAxisHorizontal = (axisType: AxisType) =>
     kHorizontalAxisTypes.indexOf(axisType) >= 0;
 
 export function axisTypeMap<T>(
-    iterator: (axisType: AxisType) => T,
+    iterator: (axisType: AxisType) => T
 ): AxisTypeMapping<T> {
     let d: Partial<AxisTypeMapping<T>> = {};
     for (let axisType of kAllAxisTypes) {
         d[axisType] = iterator(axisType);
     }
     return d as AxisTypeMapping<T>;
+}
+
+export function mergeAxisStyles(
+    ...styles: (
+        | IAxisStyle
+        | DeepPartial<IAxisStyle>
+        | IAxisStyleInput
+        | undefined
+    )[]
+): IAxisStyle {
+    // Merge regular values
+    styles = styles.filter(x => !!x);
+    let inheritedStyle = _.merge({}, kAxisStyleLightDefaults, ...styles);
+    let style: IAxisStyle = _.merge({}, inheritedStyle, {
+        padding: normalizeAnimatedValue(inheritedStyle.padding),
+        axisThickness:
+            typeof inheritedStyle.axisThickness !== 'undefined'
+                ? normalizeAnimatedValue(inheritedStyle.axisThickness)
+                : undefined,
+    });
+
+    // Merge React label styles
+    style.labelStyle.textStyle = styles
+        .map(style => style?.labelStyle?.textStyle)
+        .filter(x => !!x) as Animated.AnimatedProps<TextProps>['style'];
+    style.majorLabelStyle.textStyle = styles
+        .map(style => style?.majorLabelStyle?.textStyle)
+        .filter(x => !!x) as Animated.AnimatedProps<TextProps>['style'];
+    style.minorLabelStyle.textStyle = styles
+        .map(style => style?.minorLabelStyle?.textStyle)
+        .filter(x => !!x) as Animated.AnimatedProps<TextProps>['style'];
+
+    return style;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -7,12 +7,8 @@ import {
     kAxisStyleLightDefaults,
 } from './layout/axis/axisConst';
 import { IAxisStyle } from './layout/axis/axisTypes';
-import { IChartGridStyle } from './types';
+import { DeepPartial, IChartGridStyle } from './types';
 import { Colors } from './utils/colors';
-
-type DeepPartial<T> = {
-    [P in keyof T]?: DeepPartial<T[P]>;
-};
 
 export interface ChartTheme {
     backgroundColor?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,3 +131,7 @@ export interface IGridLayoutSourceProps
 export type ChartDataType = 'path' | 'point' | 'bar' | 'rect' | 'label';
 
 export type Cancelable = { cancel: () => void };
+
+export type DeepPartial<T> = {
+    [P in keyof T]?: DeepPartial<T[P]>;
+};


### PR DESCRIPTION
### Bug Fixes

-   When a background is specified on a label's `textStyle`, it no longer spans the whole item container width.
-   Fixed merging of axis label text styles.