### PR TITLE
Autoscale fix and optimisations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Changes on the `main` branch, but not yet released, will be listed here.
 ### Bug Fixes
 
 -   Fixed applying and merging of scale layout styles.
+-   When zooming out, the plot no longer performs unecessary renders.
+-   `LineDataSource` now redraws after a small scale changes.
+
+### Breaking Changes
+
+-   Using Evergrid v0.2.0. See [breaking changes](https://github.com/diatche/evergrid/blob/master/CHANGELOG.md#020).
 
 ## 0.8.0 - 0.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Changes on the `main` branch, but not yet released, will be listed here.
 
+### Bug Fixes
+
+-   Fixed applying and merging of scale layout styles.
+
 ## 0.8.0 - 0.8.2
 
 **26 Apr 2021**

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "homepage": "https://github.com/diatche/librechart#readme",
     "peerDependencies": {
         "decimal.js": "^10.2.1",
-        "evergrid": "~0.1.0",
+        "evergrid": "~0.2.0",
         "react": ">=16.11.0",
         "react-native": ">=0.62.0 <1.0.0",
         "react-native-svg": "^12.0.0"
@@ -53,7 +53,7 @@
         "acorn": "^6.4.2",
         "acorn-jsx": "^5.3.1",
         "decimal.js": "^10.2.1",
-        "evergrid": "~0.1.0",
+        "evergrid": "~0.2.0",
         "jest": "^26.5.2",
         "moment-timezone": "^0.5.32",
         "react-native": "^0.63.0",

--- a/src/layout/PlotLayout.ts
+++ b/src/layout/PlotLayout.ts
@@ -209,7 +209,6 @@ export default class PlotLayout<
     }
 
     didChangeViewportSize() {
-        super.didChangeViewportSize();
         this.didChangePlotSize();
     }
 
@@ -219,15 +218,39 @@ export default class PlotLayout<
         this.yLayout?.controller?.setNeedsUpdate();
     }
 
-    didChangeScale() {
-        super.didChangeScale();
-        this.schedulePlotUpdate();
-        this.xLayout?.controller?.setNeedsUpdate();
-        this.yLayout?.controller?.setNeedsUpdate();
+    willChangeScale(oldScale: IPoint, newScale: IPoint) {
+        // Only pre-update when zooming out (reducing scale),
+        // to avoid drawing extra item views
+        if (Math.abs(newScale.x) < Math.abs(oldScale.x)) {
+            this.xLayout.update();
+            this.xLayout?.controller?.setNeedsUpdate();
+        }
+        if (Math.abs(newScale.y) < Math.abs(oldScale.y)) {
+            this.yLayout.update();
+            this.yLayout?.controller?.setNeedsUpdate();
+        }
     }
 
-    didChangeLocation() {
-        super.didChangeLocation();
+    didChangeScale(oldScale: IPoint, newScale: IPoint) {
+        this.schedulePlotUpdate();
+        if (newScale.x !== oldScale.x) {
+            this.xLayout?.controller?.setNeedsUpdate();
+        }
+        if (newScale.y !== oldScale.y) {
+            this.yLayout?.controller?.setNeedsUpdate();
+        }
+    }
+
+    willChangeLocationOffsetBase(oldLocation: IPoint, newLocation: IPoint) {
+        if (newLocation.x !== oldLocation.x) {
+            this.xLayout?.controller?.update();
+        }
+        if (newLocation.y !== oldLocation.y) {
+            this.yLayout?.controller?.update();
+        }
+    }
+
+    didChangeLocationOffsetBase(oldLocation: IPoint, newLocation: IPoint) {
         this.xLayout?.controller?.setNeedsUpdate();
         this.yLayout?.controller?.setNeedsUpdate();
     }

--- a/src/layout/PlotLayout.ts
+++ b/src/layout/PlotLayout.ts
@@ -373,10 +373,18 @@ export default class PlotLayout<
 
     getAxisInsets(): Partial<IInsets<number>> {
         return {
-            top: this.axes.topAxis?.layoutInfo.thickness,
-            bottom: this.axes.bottomAxis?.layoutInfo.thickness,
-            left: this.axes.leftAxis?.layoutInfo.thickness,
-            right: this.axes.rightAxis?.layoutInfo.thickness,
+            top:
+                this.axes.topAxis?.layoutInfo.targetThickness ||
+                this.axes.topAxis?.layoutInfo.thickness,
+            bottom:
+                this.axes.bottomAxis?.layoutInfo.targetThickness ||
+                this.axes.bottomAxis?.layoutInfo.thickness,
+            left:
+                this.axes.leftAxis?.layoutInfo.targetThickness ||
+                this.axes.leftAxis?.layoutInfo.thickness,
+            right:
+                this.axes.rightAxis?.layoutInfo.targetThickness ||
+                this.axes.rightAxis?.layoutInfo.thickness,
         };
     }
 

--- a/src/layout/ScaleLayout.ts
+++ b/src/layout/ScaleLayout.ts
@@ -10,6 +10,7 @@ import ScaleController from '../scaleControllers/ScaleController';
 import DiscreteScale from '../scale/DiscreteScale';
 import AutoScaleController from '../scaleControllers/AutoScaleController';
 import _ from 'lodash';
+import { mergeAxisStyles } from './axis/axisUtil';
 
 export interface IScaleLayoutOptions<T = any, D = T> {
     /**
@@ -121,21 +122,7 @@ export default class ScaleLayout<T = number, D = T> {
             majorInterval$: new Animated.Value(0),
             negHalfMajorInterval$: new Animated.Value(0),
         };
-        let inheritedStyle = kAxisStyleLightDefaults;
-        this.style = _.merge({}, inheritedStyle, {
-            padding: normalizeAnimatedValue(style.padding, {
-                defaults: normalizeAnimatedValue(inheritedStyle.padding),
-            }),
-            axisThickness:
-                typeof style.axisThickness !== 'undefined' ||
-                typeof inheritedStyle.axisThickness !== 'undefined'
-                    ? normalizeAnimatedValue(style.axisThickness, {
-                          defaults: normalizeAnimatedValue(
-                              inheritedStyle.axisThickness
-                          ),
-                      })
-                    : undefined,
-        });
+        this.style = mergeAxisStyles(kAxisStyleLightDefaults, style);
 
         if (!controller && scale instanceof DiscreteScale) {
             controller = new AutoScaleController({

--- a/src/layout/ScaleLayout.ts
+++ b/src/layout/ScaleLayout.ts
@@ -184,7 +184,10 @@ export default class ScaleLayout<T = number, D = T> {
             // No changes
             return false;
         }
-        // console.debug(`axisLengthInfo ${this.isHorizontal ? 'H' : 'V'}: ` + JSON.stringify(axisLengthInfo, null, 2));
+        // console.debug(
+        //     `axisLengthInfo ${this.isHorizontal ? 'H' : 'V'}: ` +
+        //         JSON.stringify(axisLengthInfo, null, 2)
+        // );
 
         Object.assign(this.layoutInfo, axisLengthInfo);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,10 +2855,10 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-evergrid@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/evergrid/-/evergrid-0.1.0.tgz#429900afa6289e14f34c54775e537846be2d92fb"
-  integrity sha512-+zo6amZIhZGwWeo9CdoM3phYfPbV9yVG992+1IRspLeZRm8jzUCOPRU6VlhM6bU3tS9oLS+cEoujjSskTGOoHg==
+evergrid@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/evergrid/-/evergrid-0.2.0.tgz#b600602d8469d3a2a367ba9801993edda4a2a5a8"
+  integrity sha512-QAz6DUYmG86mtu10t+57/zl9yljou2EES+kgVQjRc4o9n/1xWauLJDuIGBoIBeEP1HdM2aCtgPvwZaf1VU2YqA==
 
 exec-sh@^0.3.2:
   version "0.3.4"


### PR DESCRIPTION
### Bug Fixes

-   Fixed applying and merging of scale layout styles.
-   When zooming out, the plot no longer performs unecessary renders.
-   `LineDataSource` now redraws after a small scale changes.

### Breaking Changes

-   Using Evergrid v0.2.0. See [breaking changes](https://github.com/diatche/evergrid/blob/master/CHANGELOG.md#020).