### PR TITLE
iOS zoom freeze fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changes on the `main` branch, but not yet released, will be listed here.
 ### Bug Fixes
 
 -   [[#40](https://github.com/diatche/LibreChart/pull/40)] Fixed a bug where the axis background would not fill completely when an axis thickness was specified.
--   Fixed a bug where zooming in would sometimes freeze on iOS when using `LineDataSource`.
+-   [[#41](https://github.com/diatche/LibreChart/pull/41)] Fixed a bug where zooming in would sometimes freeze on iOS when using `LineDataSource`.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes on the `main` branch, but not yet released, will be listed here.
 ### Bug Fixes
 
 -   [[#40](https://github.com/diatche/LibreChart/pull/40)] Fixed a bug where the axis background would not fill completely when an axis thickness was specified.
+-   Fixed a bug where zooming in would sometimes freeze on iOS when using `LineDataSource`.
 
 ## 0.9.0
 
@@ -15,8 +16,8 @@ Changes on the `main` branch, but not yet released, will be listed here.
 ### Bug Fixes
 
 -   [[#39](https://github.com/diatche/LibreChart/pull/39)] Fixed applying and merging of scale layout styles.
--   [[#39](https://github.com/diatche/LibreChart/pull/39)]When zooming out, the plot no longer performs unecessary renders.
--   [[#39](https://github.com/diatche/LibreChart/pull/39)]`LineDataSource` now redraws after a small scale changes.
+-   [[#39](https://github.com/diatche/LibreChart/pull/39)] When zooming out, the plot no longer performs unecessary renders.
+-   [[#39](https://github.com/diatche/LibreChart/pull/39)] `LineDataSource` now redraws after a small scale changes.
 
 ### Breaking Changes
 

--- a/src/data/DataSource.ts
+++ b/src/data/DataSource.ts
@@ -76,10 +76,10 @@ export default abstract class DataSource<T = any, X = number, Y = number>
         // FIXME: Do only one update if both x and y layouts change.
         this._scaleLayoutUpdates = {
             x: plot.xLayout.updates.addObserver(() =>
-                this.update(updateOptions),
+                this.update(updateOptions)
             ),
             y: plot.yLayout.updates.addObserver(() =>
-                this.update(updateOptions),
+                this.update(updateOptions)
             ),
         };
     }
@@ -94,7 +94,7 @@ export default abstract class DataSource<T = any, X = number, Y = number>
         }
     }
 
-    update(updateOptions: IItemUpdateManyOptions) {
+    update(updateOptions?: IItemUpdateManyOptions) {
         this.layout?.updateItems(updateOptions);
     }
 
@@ -105,7 +105,7 @@ export default abstract class DataSource<T = any, X = number, Y = number>
     abstract createLayoutSource(): LayoutSource;
 
     getDataBoundingRectInRange(
-        pointRange: [IPoint, IPoint],
+        pointRange: [IPoint, IPoint]
     ): [IPoint, IPoint] | undefined {
         // Get data range
         let rects = this.getDataRectsInRange(pointRange, { partial: true });
@@ -142,7 +142,7 @@ export default abstract class DataSource<T = any, X = number, Y = number>
 
     getDataRectsInRange(
         pointRange: [IPoint, IPoint],
-        options?: IItemsInLocationRangeOptions,
+        options?: IItemsInLocationRangeOptions
     ): IDataRect[] {
         let points: IDataRect[] = [];
         let xLen = pointRange[1].x - pointRange[0].x;
@@ -161,7 +161,7 @@ export default abstract class DataSource<T = any, X = number, Y = number>
                           pointRange[0].x,
                           pointRange[0].y,
                           xLen,
-                          yLen,
+                          yLen
                       )
             ) {
                 points.push({
@@ -191,7 +191,7 @@ export default abstract class DataSource<T = any, X = number, Y = number>
                           pointRange[0].x,
                           pointRange[0].y,
                           xLen,
-                          yLen,
+                          yLen
                       )
             ) {
                 indexes.push(i);

--- a/src/data/LineDataSource.ts
+++ b/src/data/LineDataSource.ts
@@ -8,7 +8,7 @@ import { VectorUtil } from '../utils/vectorUtil';
 import { LinePath, PathCurve, CanvasUtil } from '../utils/canvas';
 import PlotLayout from '../layout/PlotLayout';
 import _ from 'lodash';
-import { Animated } from 'react-native';
+import { Animated, InteractionManager } from 'react-native';
 
 export interface ILinePoint extends IDataRect {
     clipped: boolean;
@@ -32,7 +32,7 @@ export default class LineDataSource<
 > extends DataSource<T, X, Y> {
     style: ILineDataStyle;
     itemStyle?: (item: T, info: ILinePoint) => ILineDataStyle | undefined;
-    renderOnScaleDebounceInterval = 50;
+    renderOnScaleDebounceInterval = 200;
 
     private _scale$?: Animated.ValueXY;
     private _scaleUpdates?: string;
@@ -67,7 +67,10 @@ export default class LineDataSource<
     }
 
     private _updateOnScaleDebounced = _.debounce(
-        () => this.update({ visible: true, forceRender: true }),
+        () =>
+            InteractionManager.runAfterInteractions(() =>
+                this.update({ visible: true, forceRender: true })
+            ),
         this.renderOnScaleDebounceInterval
     );
 


### PR DESCRIPTION
Fixed a bug where zooming in would sometimes freeze on iOS when using `LineDataSource`.